### PR TITLE
Move the program variable to the each ODF program specific global attribute "program"

### DIFF
--- a/erddap/content/datasets.xml
+++ b/erddap/content/datasets.xml
@@ -5006,7 +5006,6 @@
       <att name="water_depth">null</att>
       <att name="mission_start_date">null</att>
       <att name="mission_end_date">null</att>
-      <att name="program">null</att>
       <att name="sounding">null</att>
       <att name="depth_off_bottom">null</att>
       <att name="event_start_time">null</att>
@@ -5018,14 +5017,6 @@
       <att name="ices_platform_code">null</att>
       <att name="wmo_platform_code">null</att>
     </addAttributes>
-    <dataVariable>
-      <sourceName>global:program</sourceName>
-      <destinationName>program</destinationName>
-      <dataType>String</dataType>
-      <addAttributes>
-        <att name="ioos_category">Other</att>
-      </addAttributes>
-    </dataVariable>
     <dataVariable>
       <sourceName>global:project</sourceName>
       <destinationName>project</destinationName>
@@ -6451,7 +6442,6 @@ AZOMP's sampling scheme off Atlantic Canada and the Labrador Sea involves annual
       <att name="water_depth">null</att>
       <att name="mission_start_date">null</att>
       <att name="mission_end_date">null</att>
-      <att name="program">null</att>
       <att name="sounding">null</att>
       <att name="depth_off_bottom">null</att>
       <att name="event_start_time">null</att>
@@ -6463,14 +6453,6 @@ AZOMP's sampling scheme off Atlantic Canada and the Labrador Sea involves annual
       <att name="ices_platform_code">null</att>
       <att name="wmo_platform_code">null</att>
     </addAttributes>
-    <dataVariable>
-      <sourceName>global:program</sourceName>
-      <destinationName>program</destinationName>
-      <dataType>String</dataType>
-      <addAttributes>
-        <att name="ioos_category">Other</att>
-      </addAttributes>
-    </dataVariable>
     <dataVariable>
       <sourceName>global:project</sourceName>
       <destinationName>project</destinationName>
@@ -7892,7 +7874,6 @@ AZOMP's sampling scheme off Atlantic Canada and the Labrador Sea involves annual
       <att name="water_depth">null</att>
       <att name="mission_start_date">null</att>
       <att name="mission_end_date">null</att>
-      <att name="program">null</att>
       <att name="sounding">null</att>
       <att name="depth_off_bottom">null</att>
       <att name="event_start_time">null</att>
@@ -7904,14 +7885,6 @@ AZOMP's sampling scheme off Atlantic Canada and the Labrador Sea involves annual
       <att name="ices_platform_code">null</att>
       <att name="wmo_platform_code">null</att>
     </addAttributes>
-    <dataVariable>
-      <sourceName>global:program</sourceName>
-      <destinationName>program</destinationName>
-      <dataType>String</dataType>
-      <addAttributes>
-        <att name="ioos_category">Other</att>
-      </addAttributes>
-    </dataVariable>
     <dataVariable>
       <sourceName>global:project</sourceName>
       <destinationName>project</destinationName>


### PR DESCRIPTION
Just a small fix to remove the program variable which is not usefull anymore since all the ODF dataset is now splitted in program specific datasets.