### PR TITLE
Fix odf platforms

### DIFF
--- a/erddap/content/datasets.xml
+++ b/erddap/content/datasets.xml
@@ -5093,8 +5093,7 @@
     <addAttributes>
       <att name="organization">Fisheries and Oceans Canada</att>
       <att name="organization_fr">Pêches et Océans Canada</att>
-      <att name="institution">Bedford Institute of Oceanography (BIO)</att>
-      <att name="institution">Institut océanographique de Bedford (BIO)</att>
+      <att name="institution">DFO BIO</att>
       <att name="cdm_data_type">Profile</att>
       <att name="cdm_profile_variables">platform_name,chief_scientist,cruise_name,cruise_number,geographic_area,id,station,event_number,profile_direction,latitude,longitude,profile_start_time,profile_end_time</att>
       <att name="Conventions">CF-1.6,CF-1.7,CF-1.8,ACDD-1.1,ACDD-1.3</att>
@@ -6534,8 +6533,7 @@
     <addAttributes>
       <att name="organization">Fisheries and Oceans Canada</att>
       <att name="organization_fr">Pêches et Océans Canada</att>
-      <att name="institution">Bedford Institute of Oceanography (BIO)</att>
-      <att name="institution">Institut océanographique de Bedford (BIO)</att>
+      <att name="institution">DFO BIO</att>
       <att name="cdm_data_type">Profile</att>
       <att name="cdm_profile_variables">platform_name,chief_scientist,cruise_name,cruise_number,geographic_area,id,station,event_number,profile_direction,latitude,longitude,profile_start_time,profile_end_time</att>
       <att name="Conventions">CF-1.6,CF-1.7,CF-1.8,ACDD-1.1,ACDD-1.3</att>
@@ -7978,8 +7976,7 @@ AZOMP's sampling scheme off Atlantic Canada and the Labrador Sea involves annual
     <addAttributes>
       <att name="organization">Fisheries and Oceans Canada</att>
       <att name="organization_fr">Pêches et Océans Canada</att>
-      <att name="institution">Bedford Institute of Oceanography (BIO)</att>
-      <att name="institution">Institut océanographique de Bedford (BIO)</att>
+      <att name="institution">DFO BIO</att>
       <att name="cdm_data_type">Profile</att>
       <att name="cdm_profile_variables">platform_name,chief_scientist,cruise_name,cruise_number,geographic_area,id,station,event_number,profile_direction,latitude,longitude,profile_start_time,profile_end_time</att>
       <att name="Conventions">CF-1.6,CF-1.7,CF-1.8,ACDD-1.1,ACDD-1.3</att>


### PR DESCRIPTION
This is a hot fix to master for some minor issues associated with the ODF datasets in production. 

-  Remove any references to QCFF variables which aren't presented in the ODF datasdet
- Replace wmo platform_id standard_name  by platform_id