### PR TITLE
fix maritimes_region_ecosystem_survey dataset institution to DFO BIO

### DIFF
--- a/erddap/content/datasets.xml
+++ b/erddap/content/datasets.xml
@@ -7994,7 +7994,6 @@ AZOMP's sampling scheme off Atlantic Canada and the Labrador Sea involves annual
       <att name="publisher_url">https://www.dfo-mpo.gc.ca/index-eng.html</att>
       <att name="publisher_name">Lindsay Beazley</att>
       <att name="date_created">2022-08-03</att>
-      <att name="institution">Fisheries and Oceans Canada,Fisheries and Oceans Canada,Fisheries and Oceans Canada</att>
       <att name="license">https://open.canada.ca/en/open-government-licence-canada</att>
       <att name="id">0270f89c-1b0a-43ea-b687-829a011c089e</att>
       <att name="naming_authority">ca.cioos</att>


### PR DESCRIPTION
The maritimes_region_ecosystem_survey didn't have the right institution due to an extra line that never got deleted